### PR TITLE
CODA-294 - Navigation should be defined per application

### DIFF
--- a/config/apps.go
+++ b/config/apps.go
@@ -1,8 +1,11 @@
 package config
 
+import "github.com/coda-it/goappframe/navigation"
+
 // App - application config
 type App struct {
-	ID      string   `json:"id"`
-	Modules []Module `json:"modules"`
-	Domain  string   `json:"domain"`
+	ID         string                  `json:"id"`
+	Modules    []Module                `json:"modules"`
+	Domain     string                  `json:"domain"`
+	Navigation []navigation.Navigation `json:"navigation"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,14 +1,9 @@
 package config
 
-import (
-	"github.com/coda-it/goappframe/navigation"
-)
-
 // Config - static app config
 type Config struct {
-	Navigation      []navigation.Navigation `json:"navigation"`
-	Apps            []App                   `json:"apps"`
-	DefaultLanguage string                  `json:"defaultLanguage"`
-	Cert            string                  `json:"certificate"`
-	CertPrvKey      string                  `json:"certificatePrivateKey"`
+	Apps            []App  `json:"apps"`
+	DefaultLanguage string `json:"defaultLanguage"`
+	Cert            string `json:"certificate"`
+	CertPrvKey      string `json:"certificatePrivateKey"`
 }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/cHVEgTG8/294-coda-294-navigation-should-be-defined-per-application

**Description:** Navigation should be kept by application not globally.