### PR TITLE
CODA-56 - Bump gowebserver dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.23.0
 
 require (
 	github.com/coda-it/goutils v0.1.0
-	github.com/coda-it/gowebserver v1.4.0
+	github.com/coda-it/gowebserver v1.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/coda-it/goutils v0.1.0 h1:cK2xlksT2yD9uIVOJHxQcHGtbY3v6m0pcL/xiB7WX/I=
 github.com/coda-it/goutils v0.1.0/go.mod h1:JDLjsDAubl3lvopKddkM1vZK8Ckq3FIeS6Ap5H6jTH0=
-github.com/coda-it/gowebserver v1.4.0 h1:zRX9uQNius2DB7fXVrV54R8rZ/BKJhK6gMjKDl4hMDM=
-github.com/coda-it/gowebserver v1.4.0/go.mod h1:o+uiz08s1yFRU7uT6+iNheCxfUBjWDyamSGkgfZ+kig=
+github.com/coda-it/gowebserver v1.4.1 h1:IgJ/IUdChwxtIahz/u5YI0yHtkxTu8zfBYbVzrO5Mh4=
+github.com/coda-it/gowebserver v1.4.1/go.mod h1:o+uiz08s1yFRU7uT6+iNheCxfUBjWDyamSGkgfZ+kig=


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-56

**Description:** Bump `gowebserver` to include security fixes.