### PR TITLE
CODA-91 - Introduce `isAdmin` permission that reflects 'admin' entitlement

### DIFF
--- a/navigation/navigation.go
+++ b/navigation/navigation.go
@@ -6,6 +6,7 @@ type Navigation struct {
 	Label    string       `json:"label"`
 	Href     string       `json:"href"`
 	IsRoot   bool         `json:"isRoot"`
+	IsAdmin  bool         `json:"isAdmin"`
 	IsLogged bool         `json:"isLogged"`
 	Children []Navigation `json:"children"`
 }

--- a/navigation/navigation_test.go
+++ b/navigation/navigation_test.go
@@ -1,0 +1,31 @@
+package navigation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNavigationSerializesIsAdmin(t *testing.T) {
+	serialized, err := json.Marshal(Navigation{
+		ID:      "admin-panel",
+		Label:   "Admin panel",
+		Href:    "/admin",
+		IsAdmin: true,
+	})
+	if err != nil {
+		t.Fatalf("marshaling navigation failed: %v", err)
+	}
+
+	var deserialized map[string]interface{}
+	if err := json.Unmarshal(serialized, &deserialized); err != nil {
+		t.Fatalf("unmarshaling navigation failed: %v", err)
+	}
+
+	isAdmin, ok := deserialized["isAdmin"]
+	if !ok {
+		t.Fatal("expected isAdmin key in serialized navigation")
+	}
+	if isAdmin != true {
+		t.Fatalf("expected isAdmin to be true, got %v", isAdmin)
+	}
+}


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-91

**Description:**

Adds an `IsAdmin` field to the `Navigation` struct (serialized as `isAdmin`) so navigation entries can reflect the 'admin' entitlement, alongside the existing `isRoot` and `isLogged` flags. Covered with a JSON serialization test.

**Visual overview:**

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)