### PR TITLE
CODA-94 - Dynamic proxy configuration

### DIFF
--- a/config/module.go
+++ b/config/module.go
@@ -1,7 +1,19 @@
 package config
 
+// ProxyRoute - a single upstream endpoint exposed through a module's reverse
+// proxy; Method and Path describe the proxied request (Path may contain
+// {param} segments), Protected requires a logged-in session and InjectAuth
+// lets the application replace the Authorization header with its own token
+type ProxyRoute struct {
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Protected  bool   `json:"protected"`
+	InjectAuth bool   `json:"injectAuth"`
+}
+
 // Module - module config
 type Module struct {
 	ID         string            `json:"id"`
 	Properties map[string]string `json:"properties"`
+	Proxy      []ProxyRoute      `json:"proxy,omitempty"`
 }

--- a/config/module_test.go
+++ b/config/module_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestModuleUnmarshalProxy(t *testing.T) {
+	moduleJSON := `{
+		"id": "eshop",
+		"properties": {"shopDomain": "https://shop.example.com"},
+		"proxy": [
+			{"method": "GET", "path": "/shops/{shopId}/products"},
+			{"method": "POST", "path": "/shops/{shopId}/products", "protected": true, "injectAuth": true}
+		]
+	}`
+
+	var moduleConfig Module
+	if err := json.Unmarshal([]byte(moduleJSON), &moduleConfig); err != nil {
+		t.Fatalf("unmarshalling module config failed: %v", err)
+	}
+
+	if len(moduleConfig.Proxy) != 2 {
+		t.Fatalf("expected 2 proxy routes, got %d", len(moduleConfig.Proxy))
+	}
+
+	firstRoute := moduleConfig.Proxy[0]
+	if firstRoute.Method != "GET" || firstRoute.Path != "/shops/{shopId}/products" {
+		t.Errorf("unexpected first proxy route: %+v", firstRoute)
+	}
+	if firstRoute.Protected || firstRoute.InjectAuth {
+		t.Errorf("proxy route flags should default to false: %+v", firstRoute)
+	}
+
+	secondRoute := moduleConfig.Proxy[1]
+	if !secondRoute.Protected || !secondRoute.InjectAuth {
+		t.Errorf("expected protected and injectAuth to be true: %+v", secondRoute)
+	}
+}
+
+func TestModuleUnmarshalWithoutProxy(t *testing.T) {
+	moduleJSON := `{"id": "post"}`
+
+	var moduleConfig Module
+	if err := json.Unmarshal([]byte(moduleJSON), &moduleConfig); err != nil {
+		t.Fatalf("unmarshalling module config failed: %v", err)
+	}
+
+	if moduleConfig.Proxy != nil {
+		t.Errorf("expected nil proxy routes when not configured, got %+v", moduleConfig.Proxy)
+	}
+}


### PR DESCRIPTION
**Business justification:** https://codait.atlassian.net/browse/CODA-94

**Description:**

Adds a typed `Proxy []ProxyRoute` field to `config.Module` so applications can declare per-module reverse-proxy allowlists (`method`, `path`, `protected`, `injectAuth`) in the app config instead of hard-coding proxied endpoints in code. Covered with JSON unmarshalling tests, including defaults when `proxy` is absent.

Consumed by the gowebapp dynamic e-shop proxy configuration (same ticket).

**Visual overview:**

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)